### PR TITLE
FlockLockStrategy should clean up lock files

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Utility/Lock/FlockLockStrategy.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Utility/Lock/FlockLockStrategy.php
@@ -19,7 +19,7 @@ use TYPO3\Flow\Utility\Files;
 /**
  * A flock based lock strategy.
  *
- * This lock strategy is based on Flock. This strategy is currently disabled on Windows.
+ * This lock strategy is based on Flock.
  *
  * @Flow\Scope("prototype")
  */
@@ -56,9 +56,6 @@ class FlockLockStrategy implements LockStrategyInterface {
 	 * @return void
 	 */
 	public function acquire($subject, $exclusiveLock) {
-		if ($this->isWindowsOS()) {
-			return;
-		}
 		if (self::$temporaryDirectory === NULL) {
 			if (Bootstrap::$staticObjectManager === NULL || !Bootstrap::$staticObjectManager->isRegistered(\TYPO3\Flow\Utility\Environment::class)) {
 				throw new LockNotAcquiredException('Environment object could not be accessed', 1386680952);
@@ -70,18 +67,31 @@ class FlockLockStrategy implements LockStrategyInterface {
 		}
 		$this->lockFileName = Files::concatenatePaths(array(self::$temporaryDirectory, md5($subject)));
 
-		if (($this->filePointer = @fopen($this->lockFileName, 'r')) === FALSE) {
-			if (($this->filePointer = @fopen($this->lockFileName, 'w')) === FALSE) {
-				throw new LockNotAcquiredException(sprintf('Lock file "%s" could not be opened', $this->lockFileName), 1386520596);
+		while (1) {
+			if (($this->filePointer = @fopen($this->lockFileName, 'r')) === FALSE) {
+				if (($this->filePointer = @fopen($this->lockFileName, 'w')) === FALSE) {
+					throw new LockNotAcquiredException(sprintf('Lock file "%s" could not be opened', $this->lockFileName), 1386520596);
+				}
 			}
-		}
 
-		if ($exclusiveLock === FALSE && flock($this->filePointer, LOCK_SH) === TRUE) {
-			// Shared lock acquired
-		} elseif ($exclusiveLock === TRUE && flock($this->filePointer, LOCK_EX) === TRUE) {
-			// Exclusive lock acquired
-		} else {
-			throw new LockNotAcquiredException(sprintf('Could not lock file "%s"', $this->lockFileName), 1386520597);
+			if ($exclusiveLock === FALSE && flock($this->filePointer, LOCK_SH) === TRUE) {
+				// Shared lock acquired
+			} elseif ($exclusiveLock === TRUE && flock($this->filePointer, LOCK_EX) === TRUE) {
+				// Exclusive lock acquired
+			} else {
+				throw new LockNotAcquiredException(sprintf('Could not lock file "%s"', $this->lockFileName), 1386520597);
+			}
+
+			$fstat = fstat($this->filePointer);
+			$stat = stat($this->lockFileName);
+			// Make sure that the file did not get unlinked between the fopen and the actual flock
+			// This will always be TRUE on windows, because 'ino' stat will always be 0, but unlink is not possible on opened files anyway
+			if ($stat !== FALSE && $stat['ino'] === $fstat['ino']) break;
+
+			flock($this->filePointer, LOCK_UN);
+			fclose($this->filePointer);
+			$this->filePointer = NULL;
+			usleep(100 + rand(0,100));
 		}
 	}
 
@@ -91,9 +101,6 @@ class FlockLockStrategy implements LockStrategyInterface {
 	 */
 	public function release() {
 		$success = TRUE;
-		if ($this->isWindowsOS()) {
-			return $success;
-		}
 		if (is_resource($this->filePointer)) {
 			if (flock($this->filePointer, LOCK_UN) === FALSE) {
 				$success = FALSE;
@@ -110,12 +117,5 @@ class FlockLockStrategy implements LockStrategyInterface {
 	 */
 	public function getLockFileName() {
 		return $this->lockFileName;
-	}
-
-	/**
-	 * @return boolean
-	 */
-	protected function isWindowsOS() {
-		return strncasecmp(PHP_OS, 'WIN', 3) == 0;
 	}
 }


### PR DESCRIPTION
The FlockLockStrategy creates files to apply the lock on.
These files reside in the temporary folder but are never cleaned
on releasing the Lock that means the amount of files in this folder
will increase over time unless the folder is cleared manually.
This change also makes the FlockLockStrategy available on
Windows.

Change-Id: I241c65485a4940324ef5818a66b840029bde0ad8
Releases: master, 3.0
